### PR TITLE
fix bug: crypto/x509/root_windows.go:112:3: cannot use uintptr(unsafe…

### DIFF
--- a/x509/ptr_sysptr_windows.go
+++ b/x509/ptr_sysptr_windows.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// +build go1.11
+package x509
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// For Go versions >= 1.11, the ExtraPolicyPara field in
+// syscall.CertChainPolicyPara is of type syscall.Pointer.  See:
+//   https://github.com/golang/go/commit/4869ec00e87ef
+func convertToPolicyParaType(p unsafe.Pointer) syscall.Pointer {
+	return (syscall.Pointer)(p)
+}

--- a/x509/root_windows.go
+++ b/x509/root_windows.go
@@ -109,7 +109,7 @@ func checkChainSSLServerPolicy(c *Certificate, chainCtx *syscall.CertChainContex
 	sslPara.Size = uint32(unsafe.Sizeof(*sslPara))
 
 	para := &syscall.CertChainPolicyPara{
-		ExtraPolicyPara: uintptr(unsafe.Pointer(sslPara)),
+		ExtraPolicyPara: convertToPolicyParaType(unsafe.Pointer(sslPara)),
 	}
 	para.Size = uint32(unsafe.Sizeof(*para))
 


### PR DESCRIPTION
….Pointer(sslPara)) (type uintptr) as type syscall.Pointer in field value